### PR TITLE
Use openclaw SDK temp path for downloaded attachments

### DIFF
--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -3,9 +3,7 @@
  */
 
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
-import * as crypto from "node:crypto";
 
 import type {
   ChannelAccountSnapshot,
@@ -13,7 +11,7 @@ import type {
   RuntimeEnv,
 } from "openclaw/plugin-sdk";
 
-import { createReplyPrefixContext } from "openclaw/plugin-sdk";
+import { buildRandomTempFilePath, createReplyPrefixContext } from "openclaw/plugin-sdk";
 
 import {
   readChannelAllowFromStore,
@@ -258,7 +256,7 @@ async function fetchFileToTemp(
       if (fnExt) ext = fnExt;
     }
     
-    const tempPath = path.join(os.tmpdir(), `openclaw-rc-${crypto.randomUUID()}${ext}`);
+    const tempPath = buildRandomTempFilePath({ prefix: "openclaw-rc", extension: ext });
     await fs.writeFile(tempPath, buffer, { mode: 0o600 });
     
     return {


### PR DESCRIPTION
The plugin downloads Rocket.Chat attachments to `os.tmpdir()` (bare `/tmp`), but openclaw's media security layer only allows reads from its own managed tmp directory (`resolvePreferredOpenClawTmpDir()`). This causes `Local media path is not under an allowed directory` errors when the agent tries to process inbound images.

Switched to `buildRandomTempFilePath` from `openclaw/plugin-sdk`, which puts temp files in the right place automatically.

```
[tools] image failed: Local media path is not under an allowed directory: /tmp/openclaw-rc-9c13e7ce-d437-4cd8-bd4f-1b267dde845c.png
```