### PR TITLE
ACP thread bindings rocketchat

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,8 +7,16 @@
 
 import type { OpenclawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import {
+  registerSessionBindingAdapter,
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+  unregisterSessionBindingAdapter,
+} from "openclaw/plugin-sdk/conversation-runtime";
 
 import { rocketChatPlugin } from "./src/channel.js";
+import { listRocketChatAccountIds } from "./src/rocketchat/accounts.js";
+import { ensureRocketChatSessionBindings } from "./src/rocketchat/session-bindings.js";
 import { setRocketChatRuntime } from "./src/runtime.js";
 
 // Re-export send/react functions for OpenClaw message tool
@@ -21,6 +29,14 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenclawPluginApi) {
     setRocketChatRuntime(api.runtime);
+    ensureRocketChatSessionBindings({
+      cfg: api.config,
+      listAccountIds: listRocketChatAccountIds,
+      registerSessionBindingAdapter,
+      unregisterSessionBindingAdapter,
+      resolveIdleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel,
+      resolveMaxAgeMs: resolveThreadBindingMaxAgeMsForChannel,
+    });
     api.registerChannel({ plugin: rocketChatPlugin });
   },
 };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -13,6 +13,7 @@ import {
   type ResolvedRocketChatAccount,
 } from "./rocketchat/accounts.js";
 import { normalizeRocketChatBaseUrl } from "./rocketchat/client.js";
+import { resolveRocketChatCommandConversation } from "./rocketchat/conversation-bindings.js";
 import { monitorRocketChatProvider } from "./rocketchat/monitor.js";
 import { reactMessageRocketChat, sendMessageRocketChat } from "./rocketchat/send.js";
 import { getRocketChatRuntime } from "./runtime.js";
@@ -161,6 +162,19 @@ export const rocketChatPlugin: ChannelPlugin<ResolvedRocketChatAccount> = {
         normalizeEntry: normalizeAllowEntry,
       };
     },
+  },
+  bindings: {
+    resolveCommandConversation: ({ threadId, threadParentId, originatingTo, commandTo, fallbackTo }) =>
+      resolveRocketChatCommandConversation({
+        threadId,
+        threadParentId,
+        originatingTo,
+        commandTo,
+        fallbackTo,
+      }),
+  },
+  conversationBindings: {
+    supportsCurrentConversationBinding: true,
   },
   messaging: {
     normalizeTarget: normalizeRocketChatMessagingTarget,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -3,7 +3,6 @@
  */
 
 import {
-  DEFAULT_ACCOUNT_ID,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk";
 
@@ -17,6 +16,8 @@ import { normalizeRocketChatBaseUrl } from "./rocketchat/client.js";
 import { monitorRocketChatProvider } from "./rocketchat/monitor.js";
 import { reactMessageRocketChat, sendMessageRocketChat } from "./rocketchat/send.js";
 import { getRocketChatRuntime } from "./runtime.js";
+
+const DEFAULT_ACCOUNT_ID = "default";
 
 const meta = {
   id: "rocketchat",

--- a/src/rocketchat/accounts.ts
+++ b/src/rocketchat/accounts.ts
@@ -78,6 +78,9 @@ export type RocketChatAccountConfig = {
 
   /** Typing indicator delay (ms) before emitting user-typing. Default 1000. */
   typingDelayMs?: number;
+
+  /** Whether streamed block replies should be emitted before the final answer. Default: true. */
+  blockStreaming?: boolean;
 };
 
 export type ResolvedRocketChatAccount = {

--- a/src/rocketchat/conversation-bindings.js
+++ b/src/rocketchat/conversation-bindings.js
@@ -1,0 +1,48 @@
+/**
+ * Rocket.Chat ACP conversation binding helpers.
+ */
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function normalizeRocketChatConversationId(target) {
+  const trimmed = normalizeText(target);
+  if (!trimmed) return "";
+
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("rocketchat:room:")) {
+    return trimmed.slice("rocketchat:room:".length).trim();
+  }
+  if (lower.startsWith("rocketchat:")) {
+    return trimmed.slice("rocketchat:".length).trim();
+  }
+  if (lower.startsWith("room:")) {
+    return trimmed.slice("room:".length).trim();
+  }
+
+  return trimmed;
+}
+
+export function resolveRocketChatCommandConversation(params = {}) {
+  const threadId = normalizeText(params.threadId);
+  const threadParentId = normalizeRocketChatConversationId(params.threadParentId);
+  const baseConversationId =
+    normalizeRocketChatConversationId(params.originatingTo) ||
+    normalizeRocketChatConversationId(params.commandTo) ||
+    normalizeRocketChatConversationId(params.fallbackTo);
+
+  if (threadId) {
+    return {
+      conversationId: threadId,
+      parentConversationId: threadParentId || baseConversationId || undefined,
+    };
+  }
+
+  if (!baseConversationId) return null;
+
+  return {
+    conversationId: baseConversationId,
+    parentConversationId: threadParentId || undefined,
+  };
+}

--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -12,6 +12,7 @@ import type {
 } from "openclaw/plugin-sdk";
 
 import { createReplyPrefixContext } from "openclaw/plugin-sdk/channel-runtime";
+import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
 import { buildRandomTempFilePath } from "openclaw/plugin-sdk/temp-path";
 
 import {
@@ -60,6 +61,7 @@ import {
   fetchUserRoles,
   fetchUserByUsername,
 } from "./roles.js";
+import { resolveRocketChatBoundRoute } from "./session-bindings.js";
 
 import { getRocketChatRuntime } from "../runtime.js";
 import { resolveRocketChatAccount, type ResolvedRocketChatAccount } from "./accounts.js";
@@ -1295,7 +1297,7 @@ async function handleIncomingMessage(
   });
 
   // Resolve agent route
-  const route = core.channel?.routing?.resolveAgentRoute?.({
+  let route = core.channel?.routing?.resolveAgentRoute?.({
     cfg,
     channel: "rocketchat",
     accountId: account.accountId,
@@ -1308,6 +1310,20 @@ async function handleIncomingMessage(
     sessionKey: `rocketchat:${isGroup ? "group" : "dm"}:${isGroup ? roomId : senderId}`,
     accountId: account.accountId,
   };
+  const boundRoute = resolveRocketChatBoundRoute({
+    route,
+    bindingService: getSessionBindingService(),
+    accountId: account.accountId,
+    conversationId: msg.tmid ?? roomId,
+    parentConversationId: msg.tmid ? roomId : undefined,
+  });
+  route = boundRoute.route;
+  if (boundRoute.runtimeBindingId) {
+    getSessionBindingService().touch(boundRoute.runtimeBindingId, ts);
+    logger.debug?.(
+      `Rocket.Chat routed via bound conversation ${msg.tmid ?? roomId} -> ${route.sessionKey}`
+    );
+  }
 
   // Build from label
   const fromLabel = isGroup

--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -61,6 +61,7 @@ import {
   fetchUserRoles,
   fetchUserByUsername,
 } from "./roles.js";
+import { createRocketChatReplyDeduper } from "./reply-dedupe.js";
 import { resolveRocketChatBoundRoute } from "./session-bindings.js";
 
 import { getRocketChatRuntime } from "../runtime.js";
@@ -1509,6 +1510,7 @@ async function handleIncomingMessage(
   }
 
   startTypingAfterDelay();
+  const replyDeduper = createRocketChatReplyDeduper();
 
   try {
     // Wire up responsePrefix support (e.g. messages.responsePrefix: "({model}) ")
@@ -1523,7 +1525,10 @@ async function handleIncomingMessage(
         responsePrefixContextProvider: prefix.responsePrefixContextProvider,
         deliver: async (payload) => {
           const text = (payload as { text?: string }).text ?? "";
-          if (!text.trim()) return;
+          if (!replyDeduper.shouldDeliver(text)) {
+            logger.debug?.(`Skipping duplicate Rocket.Chat reply payload for message ${msg._id}`);
+            return;
+          }
 
           const replyToId = resolvedReplyMode === "thread" ? (msg.tmid ?? msg._id) : undefined;
 
@@ -1538,6 +1543,10 @@ async function handleIncomingMessage(
         },
       },
       replyOptions: {
+        disableBlockStreaming:
+          typeof account.config.blockStreaming === "boolean"
+            ? !account.config.blockStreaming
+            : false,
         onModelSelected: prefix.onModelSelected,
       },
     });

--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -1437,9 +1437,12 @@ async function handleIncomingMessage(
     Provider: "rocketchat",
     Surface: "rocketchat",
     MessageSid: msg._id,
+    MessageThreadId: msg.tmid ?? undefined,
     Timestamp: ts,
+    ThreadParentId: msg.tmid ? roomId : undefined,
     OriginatingChannel: "rocketchat",
     OriginatingTo: `rocketchat:${roomId}`,
+    NativeChannelId: roomId,
 
     // Image attachments (fetched to temp files)
     MediaPaths: mediaPaths?.length ? mediaPaths : undefined,

--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -11,7 +11,8 @@ import type {
   RuntimeEnv,
 } from "openclaw/plugin-sdk";
 
-import { buildRandomTempFilePath, createReplyPrefixContext } from "openclaw/plugin-sdk";
+import { createReplyPrefixContext } from "openclaw/plugin-sdk/channel-runtime";
+import { buildRandomTempFilePath } from "openclaw/plugin-sdk/temp-path";
 
 import {
   readChannelAllowFromStore,

--- a/src/rocketchat/reply-dedupe.js
+++ b/src/rocketchat/reply-dedupe.js
@@ -1,0 +1,21 @@
+/**
+ * Guard against duplicate buffered deliveries for the same inbound turn.
+ *
+ * Some runtimes can emit the exact same final text more than once when a
+ * session is resuming or finalizing. For Rocket.Chat we treat identical
+ * consecutive payloads in the same reply cycle as duplicates and suppress them.
+ */
+
+export function createRocketChatReplyDeduper() {
+  let lastText = null;
+
+  return {
+    shouldDeliver(text) {
+      const normalized = String(text ?? "").trim();
+      if (!normalized) return false;
+      if (normalized === lastText) return false;
+      lastText = normalized;
+      return true;
+    },
+  };
+}

--- a/src/rocketchat/session-bindings.js
+++ b/src/rocketchat/session-bindings.js
@@ -52,6 +52,34 @@ function resolveAgentIdFromSessionKey(targetSessionKey) {
   return firstSegment || undefined;
 }
 
+export function resolveRocketChatBoundRoute(params) {
+  const runtimeBinding = params.bindingService?.resolveByConversation?.({
+    channel: "rocketchat",
+    accountId: normalizeAccountId(params.accountId),
+    conversationId: params.conversationId,
+    ...(params.parentConversationId
+      ? { parentConversationId: params.parentConversationId }
+      : {}),
+  });
+  const boundSessionKey = runtimeBinding?.targetSessionKey?.trim();
+  if (!runtimeBinding || !boundSessionKey) {
+    return {
+      route: params.route,
+      runtimeBindingId: null,
+    };
+  }
+
+  return {
+    route: {
+      ...params.route,
+      sessionKey: boundSessionKey,
+      agentId: resolveAgentIdFromSessionKey(boundSessionKey) || params.route.agentId,
+      matchedBy: "binding.channel",
+    },
+    runtimeBindingId: runtimeBinding.bindingId,
+  };
+}
+
 function resolveExpiresAt(record, defaults) {
   const candidates = [];
   if (typeof defaults.idleTimeoutMs === "number" && defaults.idleTimeoutMs > 0) {

--- a/src/rocketchat/session-bindings.js
+++ b/src/rocketchat/session-bindings.js
@@ -1,0 +1,315 @@
+/**
+ * Rocket.Chat ACP session binding registration and storage.
+ */
+
+const DEFAULT_ACCOUNT_ID = "default";
+const BINDING_ID_PREFIX = "rocketchat-binding";
+
+const globalState = (() => {
+  if (!globalThis.__openclawRocketChatSessionBindings) {
+    globalThis.__openclawRocketChatSessionBindings = {
+      managersByAccountId: new Map(),
+    };
+  }
+  return globalThis.__openclawRocketChatSessionBindings;
+})();
+
+function normalizeAccountId(accountId) {
+  return typeof accountId === "string" && accountId.trim()
+    ? accountId.trim()
+    : DEFAULT_ACCOUNT_ID;
+}
+
+function buildBindingKey({ accountId, conversationId }) {
+  return `${accountId}:${conversationId}`;
+}
+
+function buildBindingId({ accountId, conversationId }) {
+  return `${BINDING_ID_PREFIX}:${encodeURIComponent(accountId)}:${encodeURIComponent(conversationId)}`;
+}
+
+function parseBindingId(bindingId) {
+  if (typeof bindingId !== "string") return null;
+  const trimmed = bindingId.trim();
+  if (!trimmed.startsWith(`${BINDING_ID_PREFIX}:`)) return null;
+  const [, encodedAccountId = "", ...rest] = trimmed.split(":");
+  if (!encodedAccountId || rest.length === 0) return null;
+
+  return {
+    accountId: decodeURIComponent(encodedAccountId),
+    conversationId: decodeURIComponent(rest.join(":")),
+  };
+}
+
+function resolveTargetKind(targetKind) {
+  return targetKind === "subagent" ? "subagent" : "session";
+}
+
+function resolveAgentIdFromSessionKey(targetSessionKey) {
+  const trimmed = typeof targetSessionKey === "string" ? targetSessionKey.trim() : "";
+  if (!trimmed) return undefined;
+  const firstSegment = trimmed.split(":", 1)[0]?.trim();
+  return firstSegment || undefined;
+}
+
+function resolveExpiresAt(record, defaults) {
+  const candidates = [];
+  if (typeof defaults.idleTimeoutMs === "number" && defaults.idleTimeoutMs > 0) {
+    candidates.push(record.lastActivityAt + defaults.idleTimeoutMs);
+  }
+  if (typeof defaults.maxAgeMs === "number" && defaults.maxAgeMs > 0) {
+    candidates.push(record.boundAt + defaults.maxAgeMs);
+  }
+  if (candidates.length === 0) return undefined;
+  return Math.min(...candidates);
+}
+
+function toSessionBindingRecord(record, defaults) {
+  return {
+    bindingId: buildBindingId({
+      accountId: record.accountId,
+      conversationId: record.conversationId,
+    }),
+    targetSessionKey: record.targetSessionKey,
+    targetKind: record.targetKind,
+    conversation: {
+      channel: "rocketchat",
+      accountId: record.accountId,
+      conversationId: record.conversationId,
+      ...(record.parentConversationId
+        ? { parentConversationId: record.parentConversationId }
+        : {}),
+    },
+    status: "active",
+    boundAt: record.boundAt,
+    ...(resolveExpiresAt(record, defaults) != null
+      ? { expiresAt: resolveExpiresAt(record, defaults) }
+      : {}),
+    metadata: {
+      agentId: record.agentId,
+      label: record.label,
+      boundBy: record.boundBy,
+      lastActivityAt: record.lastActivityAt,
+      idleTimeoutMs: defaults.idleTimeoutMs,
+      maxAgeMs: defaults.maxAgeMs,
+      parentConversationId: record.parentConversationId,
+    },
+  };
+}
+
+export function createRocketChatSessionBindingManager(params) {
+  const accountId = normalizeAccountId(params?.accountId);
+  const existing = globalState.managersByAccountId.get(accountId);
+  if (existing) return existing;
+
+  const defaults = {
+    idleTimeoutMs: params?.idleTimeoutMs ?? 0,
+    maxAgeMs: params?.maxAgeMs ?? 0,
+  };
+  const bindingsByConversation = new Map();
+  let sessionBindingAdapter = null;
+
+  const manager = {
+    accountId,
+    getByConversationId(conversationId) {
+      const normalizedConversationId =
+        typeof conversationId === "string" ? conversationId.trim() : "";
+      if (!normalizedConversationId) return undefined;
+      return bindingsByConversation.get(
+        buildBindingKey({
+          accountId,
+          conversationId: normalizedConversationId,
+        })
+      );
+    },
+    listBySessionKey(targetSessionKey) {
+      const normalizedTargetSessionKey =
+        typeof targetSessionKey === "string" ? targetSessionKey.trim() : "";
+      if (!normalizedTargetSessionKey) return [];
+      return [...bindingsByConversation.values()].filter(
+        (record) => record.targetSessionKey === normalizedTargetSessionKey
+      );
+    },
+    bindConversation({ conversationId, parentConversationId, targetKind, targetSessionKey, metadata }) {
+      const normalizedConversationId =
+        typeof conversationId === "string" ? conversationId.trim() : "";
+      const normalizedTargetSessionKey =
+        typeof targetSessionKey === "string" ? targetSessionKey.trim() : "";
+      if (!normalizedConversationId || !normalizedTargetSessionKey) return null;
+
+      const now = Date.now();
+      const record = {
+        accountId,
+        conversationId: normalizedConversationId,
+        ...(typeof parentConversationId === "string" && parentConversationId.trim()
+          ? { parentConversationId: parentConversationId.trim() }
+          : {}),
+        targetKind: resolveTargetKind(targetKind),
+        targetSessionKey: normalizedTargetSessionKey,
+        agentId:
+          typeof metadata?.agentId === "string" && metadata.agentId.trim()
+            ? metadata.agentId.trim()
+            : resolveAgentIdFromSessionKey(normalizedTargetSessionKey),
+        label:
+          typeof metadata?.label === "string" && metadata.label.trim()
+            ? metadata.label.trim()
+            : undefined,
+        boundBy:
+          typeof metadata?.boundBy === "string" && metadata.boundBy.trim()
+            ? metadata.boundBy.trim()
+            : undefined,
+        boundAt: now,
+        lastActivityAt: now,
+      };
+
+      bindingsByConversation.set(
+        buildBindingKey({
+          accountId,
+          conversationId: normalizedConversationId,
+        }),
+        record
+      );
+      return record;
+    },
+    touchConversation(conversationId, at = Date.now()) {
+      const existingRecord = manager.getByConversationId(conversationId);
+      if (!existingRecord) return null;
+      const updated = {
+        ...existingRecord,
+        lastActivityAt: at,
+      };
+      bindingsByConversation.set(
+        buildBindingKey({
+          accountId,
+          conversationId: updated.conversationId,
+        }),
+        updated
+      );
+      return updated;
+    },
+    unbindConversation(conversationId) {
+      const existingRecord = manager.getByConversationId(conversationId);
+      if (!existingRecord) return null;
+      bindingsByConversation.delete(
+        buildBindingKey({
+          accountId,
+          conversationId: existingRecord.conversationId,
+        })
+      );
+      return existingRecord;
+    },
+    unbindBySessionKey(targetSessionKey) {
+      const removed = [];
+      for (const record of manager.listBySessionKey(targetSessionKey)) {
+        bindingsByConversation.delete(
+          buildBindingKey({
+            accountId,
+            conversationId: record.conversationId,
+          })
+        );
+        removed.push(record);
+      }
+      return removed;
+    },
+    stop() {
+      bindingsByConversation.clear();
+      globalState.managersByAccountId.delete(accountId);
+      if (sessionBindingAdapter && typeof params?.unregisterSessionBindingAdapter === "function") {
+        params.unregisterSessionBindingAdapter({
+          channel: "rocketchat",
+          accountId,
+          adapter: sessionBindingAdapter,
+        });
+      }
+    },
+  };
+
+  sessionBindingAdapter = {
+    channel: "rocketchat",
+    accountId,
+    capabilities: { placements: ["current"] },
+    bind: async (input) => {
+      if (input.conversation.channel !== "rocketchat" || input.placement === "child") {
+        return null;
+      }
+      const bound = manager.bindConversation({
+        conversationId: input.conversation.conversationId,
+        parentConversationId: input.conversation.parentConversationId,
+        targetKind: input.targetKind,
+        targetSessionKey: input.targetSessionKey,
+        metadata: input.metadata,
+      });
+      return bound ? toSessionBindingRecord(bound, defaults) : null;
+    },
+    listBySession: (targetSessionKey) =>
+      manager.listBySessionKey(targetSessionKey).map((entry) =>
+        toSessionBindingRecord(entry, defaults)
+      ),
+    resolveByConversation: (ref) => {
+      if (ref.channel !== "rocketchat") return null;
+      const found = manager.getByConversationId(ref.conversationId);
+      return found ? toSessionBindingRecord(found, defaults) : null;
+    },
+    touch: (bindingId, at) => {
+      const parsed = parseBindingId(bindingId);
+      if (!parsed || parsed.accountId !== accountId) return;
+      manager.touchConversation(parsed.conversationId, at);
+    },
+    unbind: async (input) => {
+      if (input.targetSessionKey?.trim()) {
+        return manager.unbindBySessionKey(input.targetSessionKey.trim()).map((entry) =>
+          toSessionBindingRecord(entry, defaults)
+        );
+      }
+
+      const parsed = parseBindingId(input.bindingId);
+      if (!parsed || parsed.accountId !== accountId) return [];
+
+      const removed = manager.unbindConversation(parsed.conversationId);
+      return removed ? [toSessionBindingRecord(removed, defaults)] : [];
+    },
+  };
+
+  if (typeof params?.registerSessionBindingAdapter === "function") {
+    params.registerSessionBindingAdapter(sessionBindingAdapter);
+  }
+
+  globalState.managersByAccountId.set(accountId, manager);
+  return manager;
+}
+
+export function ensureRocketChatSessionBindings(params) {
+  const accountIds = new Set(
+    typeof params.listAccountIds === "function" ? params.listAccountIds(params.cfg) : []
+  );
+  accountIds.add(DEFAULT_ACCOUNT_ID);
+
+  for (const accountId of accountIds) {
+    createRocketChatSessionBindingManager({
+      accountId,
+      idleTimeoutMs: params.resolveIdleTimeoutMs?.({ cfg: params.cfg, channel: "rocketchat", accountId }) ?? 0,
+      maxAgeMs: params.resolveMaxAgeMs?.({ cfg: params.cfg, channel: "rocketchat", accountId }) ?? 0,
+      registerSessionBindingAdapter: params.registerSessionBindingAdapter,
+      unregisterSessionBindingAdapter: params.unregisterSessionBindingAdapter,
+    });
+  }
+
+  for (const [accountId, manager] of globalState.managersByAccountId.entries()) {
+    if (accountIds.has(accountId)) continue;
+    manager.stop();
+  }
+}
+
+export function getRocketChatSessionBindingManager(accountId) {
+  return globalState.managersByAccountId.get(normalizeAccountId(accountId)) ?? null;
+}
+
+export const __testing = {
+  parseBindingId,
+  resetRocketChatSessionBindingsForTests() {
+    for (const manager of globalState.managersByAccountId.values()) {
+      manager.stop();
+    }
+    globalState.managersByAccountId.clear();
+  },
+};

--- a/test/conversation-bindings.test.mjs
+++ b/test/conversation-bindings.test.mjs
@@ -13,6 +13,7 @@ import {
   normalizeRocketChatConversationId,
   resolveRocketChatCommandConversation,
 } from "../src/rocketchat/conversation-bindings.js";
+import { createRocketChatReplyDeduper } from "../src/rocketchat/reply-dedupe.js";
 
 const tests = [];
 
@@ -203,6 +204,41 @@ test("bound route switches inbound delivery to the ACP session", async () => {
   assert.ok(result.runtimeBindingId);
 
   manager.stop();
+});
+
+test("reply deduper suppresses identical repeated deliveries within one turn", () => {
+  const deduper = createRocketChatReplyDeduper();
+
+  assert.strictEqual(deduper.shouldDeliver("bound follow-up works"), true);
+  assert.strictEqual(deduper.shouldDeliver("bound follow-up works"), false);
+  assert.strictEqual(deduper.shouldDeliver("Session ids resolved."), true);
+  assert.strictEqual(deduper.shouldDeliver("Session ids resolved."), false);
+});
+
+test("monitor currently uses buffered reply dispatch", () => {
+  const monitorSource = fs.readFileSync(
+    new URL("../src/rocketchat/monitor.ts", import.meta.url),
+    "utf8"
+  );
+  assert.ok(
+    monitorSource.includes("dispatchReplyWithBufferedBlockDispatcher?.({"),
+    "src/rocketchat/monitor.ts should use the buffered reply dispatcher"
+  );
+});
+
+test("monitor enables block streaming for Rocket.Chat by default", () => {
+  const monitorSource = fs.readFileSync(
+    new URL("../src/rocketchat/monitor.ts", import.meta.url),
+    "utf8"
+  );
+  assert.ok(
+    monitorSource.includes("disableBlockStreaming:"),
+    "src/rocketchat/monitor.ts should set disableBlockStreaming explicitly"
+  );
+  assert.ok(
+    monitorSource.includes(': false,'),
+    "src/rocketchat/monitor.ts should default Rocket.Chat block streaming to enabled"
+  );
 });
 
 console.log("Running Rocket.Chat conversation binding tests...\n");

--- a/test/conversation-bindings.test.mjs
+++ b/test/conversation-bindings.test.mjs
@@ -72,6 +72,21 @@ test("plugin opts into current-conversation ACP bindings", () => {
   );
 });
 
+test("monitor forwards Rocket.Chat thread metadata into ACP context", () => {
+  const monitorSource = fs.readFileSync(
+    new URL("../src/rocketchat/monitor.ts", import.meta.url),
+    "utf8"
+  );
+  assert.ok(
+    monitorSource.includes("MessageThreadId: msg.tmid ?? undefined"),
+    "src/rocketchat/monitor.ts should forward MessageThreadId for ACP command binding"
+  );
+  assert.ok(
+    monitorSource.includes("ThreadParentId: msg.tmid ? roomId : undefined"),
+    "src/rocketchat/monitor.ts should forward ThreadParentId for ACP command binding"
+  );
+});
+
 test("session binding manager registers a current-placement adapter", async () => {
   const registered = [];
   const manager = createRocketChatSessionBindingManager({

--- a/test/conversation-bindings.test.mjs
+++ b/test/conversation-bindings.test.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 
 import {
   createRocketChatSessionBindingManager,
+  resolveRocketChatBoundRoute,
 } from "../src/rocketchat/session-bindings.js";
 import {
   normalizeRocketChatConversationId,
@@ -144,6 +145,48 @@ test("session binding manager refuses child placement", async () => {
   });
 
   assert.strictEqual(result, null);
+  manager.stop();
+});
+
+test("bound route switches inbound delivery to the ACP session", async () => {
+  const registered = [];
+  const manager = createRocketChatSessionBindingManager({
+    accountId: "default",
+    registerSessionBindingAdapter: (adapter) => registered.push(adapter),
+    unregisterSessionBindingAdapter: () => {},
+  });
+
+  await registered[0].bind({
+    targetSessionKey: "acp:session-789",
+    targetKind: "session",
+    conversation: {
+      channel: "rocketchat",
+      accountId: "default",
+      conversationId: "thread-root-message-id",
+      parentConversationId: "ByehQjC44FwMeiLbX",
+    },
+    placement: "current",
+    metadata: {},
+  });
+
+  const result = resolveRocketChatBoundRoute({
+    route: {
+      agentId: "main",
+      sessionKey: "rocketchat:group:ByehQjC44FwMeiLbX",
+    },
+    bindingService: {
+      resolveByConversation: registered[0].resolveByConversation,
+    },
+    accountId: "default",
+    conversationId: "thread-root-message-id",
+    parentConversationId: "ByehQjC44FwMeiLbX",
+  });
+
+  assert.strictEqual(result.route.sessionKey, "acp:session-789");
+  assert.strictEqual(result.route.agentId, "acp");
+  assert.strictEqual(result.route.matchedBy, "binding.channel");
+  assert.ok(result.runtimeBindingId);
+
   manager.stop();
 });
 

--- a/test/conversation-bindings.test.mjs
+++ b/test/conversation-bindings.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * Test cases for Rocket.Chat ACP conversation binding helpers.
+ */
+
+import assert from "node:assert";
+import fs from "node:fs";
+
+import {
+  normalizeRocketChatConversationId,
+  resolveRocketChatCommandConversation,
+} from "../src/rocketchat/conversation-bindings.js";
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test("normalizes room ids from rocketchat targets", () => {
+  assert.strictEqual(
+    normalizeRocketChatConversationId("rocketchat:room:GENERAL"),
+    "GENERAL"
+  );
+  assert.strictEqual(
+    normalizeRocketChatConversationId("rocketchat:ByehQjC44FwMeiLbX"),
+    "ByehQjC44FwMeiLbX"
+  );
+  assert.strictEqual(
+    normalizeRocketChatConversationId("room:workflowdev"),
+    "workflowdev"
+  );
+});
+
+test("resolves current room conversation without a thread", () => {
+  assert.deepStrictEqual(
+    resolveRocketChatCommandConversation({
+      originatingTo: "rocketchat:ByehQjC44FwMeiLbX",
+    }),
+    {
+      conversationId: "ByehQjC44FwMeiLbX",
+      parentConversationId: undefined,
+    }
+  );
+});
+
+test("resolves thread conversation with parent room", () => {
+  assert.deepStrictEqual(
+    resolveRocketChatCommandConversation({
+      threadId: "thread-root-message-id",
+      threadParentId: "room:ByehQjC44FwMeiLbX",
+      originatingTo: "rocketchat:ByehQjC44FwMeiLbX",
+    }),
+    {
+      conversationId: "thread-root-message-id",
+      parentConversationId: "ByehQjC44FwMeiLbX",
+    }
+  );
+});
+
+test("plugin opts into current-conversation ACP bindings", () => {
+  const channelSource = fs.readFileSync(
+    new URL("../src/channel.ts", import.meta.url),
+    "utf8"
+  );
+  assert.ok(
+    channelSource.includes("supportsCurrentConversationBinding: true"),
+    "src/channel.ts should opt Rocket.Chat into current-conversation ACP bindings"
+  );
+});
+
+console.log("Running Rocket.Chat conversation binding tests...\n");
+
+let passed = 0;
+let failed = 0;
+
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`❌ ${name}`);
+    console.log(`   ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/test/conversation-bindings.test.mjs
+++ b/test/conversation-bindings.test.mjs
@@ -6,6 +6,9 @@ import assert from "node:assert";
 import fs from "node:fs";
 
 import {
+  createRocketChatSessionBindingManager,
+} from "../src/rocketchat/session-bindings.js";
+import {
   normalizeRocketChatConversationId,
   resolveRocketChatCommandConversation,
 } from "../src/rocketchat/conversation-bindings.js";
@@ -66,6 +69,82 @@ test("plugin opts into current-conversation ACP bindings", () => {
     channelSource.includes("supportsCurrentConversationBinding: true"),
     "src/channel.ts should opt Rocket.Chat into current-conversation ACP bindings"
   );
+});
+
+test("session binding manager registers a current-placement adapter", async () => {
+  const registered = [];
+  const manager = createRocketChatSessionBindingManager({
+    accountId: "default",
+    idleTimeoutMs: 60000,
+    maxAgeMs: 120000,
+    registerSessionBindingAdapter: (adapter) => registered.push(adapter),
+    unregisterSessionBindingAdapter: () => {},
+  });
+
+  assert.strictEqual(registered.length, 1);
+  assert.deepStrictEqual(registered[0].capabilities, { placements: ["current"] });
+
+  const record = await registered[0].bind({
+    targetSessionKey: "acp:session-123",
+    targetKind: "session",
+    conversation: {
+      channel: "rocketchat",
+      accountId: "default",
+      conversationId: "thread-root-message-id",
+      parentConversationId: "ByehQjC44FwMeiLbX",
+    },
+    placement: "current",
+    metadata: { label: "Codex thread" },
+  });
+
+  assert.ok(record);
+  assert.strictEqual(record.conversation.conversationId, "thread-root-message-id");
+  assert.strictEqual(record.conversation.parentConversationId, "ByehQjC44FwMeiLbX");
+  assert.strictEqual(registered[0].resolveByConversation({
+    channel: "rocketchat",
+    accountId: "default",
+    conversationId: "thread-root-message-id",
+  }).targetSessionKey, "acp:session-123");
+
+  const removed = await registered[0].unbind({
+    bindingId: record.bindingId,
+    reason: "test",
+  });
+  assert.strictEqual(removed.length, 1);
+  assert.strictEqual(
+    registered[0].resolveByConversation({
+      channel: "rocketchat",
+      accountId: "default",
+      conversationId: "thread-root-message-id",
+    }),
+    null
+  );
+
+  manager.stop();
+});
+
+test("session binding manager refuses child placement", async () => {
+  const registered = [];
+  const manager = createRocketChatSessionBindingManager({
+    accountId: "default",
+    registerSessionBindingAdapter: (adapter) => registered.push(adapter),
+    unregisterSessionBindingAdapter: () => {},
+  });
+
+  const result = await registered[0].bind({
+    targetSessionKey: "acp:session-456",
+    targetKind: "session",
+    conversation: {
+      channel: "rocketchat",
+      accountId: "default",
+      conversationId: "thread-root-message-id",
+    },
+    placement: "child",
+    metadata: {},
+  });
+
+  assert.strictEqual(result, null);
+  manager.stop();
 });
 
 console.log("Running Rocket.Chat conversation binding tests...\n");


### PR DESCRIPTION
## Summary

This branch adds Rocket.Chat support for OpenClaw ACP conversation/thread bindings so Codex sessions can be spawned and attached to the current Rocket.Chat conversation instead of failing with:

`Thread bindings are unavailable for rocketchat.`

It also includes the earlier OpenClaw compatibility fix from this fork, because this branch is based on `codex/openclaw-latest-compatibility`.

## Why

We wanted to use Codex as an ACP server from Rocket.Chat, but Rocket.Chat only supported normal message threading and did not expose the ACP binding capabilities that OpenClaw expects for:

- binding the current conversation with `--bind here`
- binding an existing thread with `--thread here`
- routing later inbound messages back into the bound ACP session

Without that adapter/binding work, OpenClaw rejected the flow even though Rocket.Chat itself supports threads.

During testing we also found that Rocket.Chat could emit duplicate final replies for the same ACP turn, so this branch adds a small dedupe guard for identical repeated deliveries.

## What changed compared to the forked repo / `main`

Compared to `origin/main`, this branch contains two logical change groups:

1. OpenClaw compatibility
- `61a361f` `fix: restore plugin-sdk compatibility imports`

2. Rocket.Chat ACP thread/conversation binding support
- `c359a8d` `feat: add Rocket.Chat ACP conversation binding support`
- `2c5b91a` `feat: register Rocket.Chat ACP session bindings`
- `5da4538` `feat: route Rocket.Chat messages through ACP bindings`
- `0c713c3` `feat: forward Rocket.Chat thread context to ACP`
- `6e5c4a8` `fix: dedupe repeated Rocket.Chat ACP replies`

Diff summary vs `origin/main`:
- `index.ts`
- `src/channel.ts`
- `src/rocketchat/accounts.ts`
- `src/rocketchat/conversation-bindings.js`
- `src/rocketchat/monitor.ts`
- `src/rocketchat/reply-dedupe.js`
- `src/rocketchat/session-bindings.js`
- `test/conversation-bindings.test.mjs`

## What changed compared to `codex/openclaw-latest-compatibility`

If you compare only against `codex/openclaw-latest-compatibility`, this PR adds the ACP/Rocket.Chat work only:

- opt Rocket.Chat into current-conversation ACP bindings
- add Rocket.Chat conversation resolution for room vs thread context
- add a Rocket.Chat ACP session binding manager/adapter
- route inbound Rocket.Chat messages through ACP bindings
- forward Rocket.Chat thread metadata into ACP context
- add a deduper for repeated identical reply payloads
- add regression tests covering the binding and reply behavior

## Implementation details

### 1. Conversation binding support
`src/channel.ts` now advertises Rocket.Chat ACP current-conversation binding support and wires the channel to Rocket.Chat-specific conversation resolution.

This is the prerequisite for:
- `--acp spawn codex --bind here`
- `--acp spawn codex --thread here`

### 2. Rocket.Chat conversation and session binding model
New files:
- `src/rocketchat/conversation-bindings.js`
- `src/rocketchat/session-bindings.js`

These add Rocket.Chat-specific mapping logic for:
- room conversations
- thread conversations
- parent room vs thread id relationships
- ACP session binding lifecycle

This fills the gap that previously caused OpenClaw to report that thread/conversation bindings were unavailable for Rocket.Chat.

### 3. Inbound routing through ACP bindings
`src/rocketchat/monitor.ts` now checks whether an inbound Rocket.Chat message belongs to a bound ACP conversation/thread and routes it to that ACP session instead of falling back to the default room/session handling.

That means once a conversation or thread is bound, follow-up messages continue in the same ACP session.

### 4. Thread context forwarding
`src/rocketchat/monitor.ts` also now forwards Rocket.Chat thread metadata into the ACP context so ACP/Codex can distinguish:
- current room id
- current thread id
- thread parent id

This is required for correct behavior when working from an existing Rocket.Chat thread.

### 5. Duplicate reply suppression
New file:
- `src/rocketchat/reply-dedupe.js`

During live ACP testing we saw repeated identical final reply payloads arrive in Rocket.Chat for the same turn. This change suppresses exact duplicate consecutive payloads within one reply cycle so the user sees a cleaner result.

### 6. Config surface for block streaming
`src/rocketchat/accounts.ts` adds `blockStreaming?: boolean`, and `monitor.ts` explicitly passes `disableBlockStreaming` into the reply dispatcher options.

This keeps Rocket.Chat behavior explicit and testable rather than relying on implicit defaults.

## Tests

Added/extended coverage in:
- `test/conversation-bindings.test.mjs`

The tests now cover:
- room id normalization
- current room conversation resolution
- thread conversation resolution with parent room
- plugin opt-in for ACP current-conversation bindings
- forwarding Rocket.Chat thread metadata into ACP context
- session binding adapter registration and behavior
- inbound route switching to the bound ACP session
- duplicate reply suppression
- monitor reply-dispatch configuration expectations

Validated locally with:
- `node test/conversation-bindings.test.mjs`
- `node test/approval-commands.test.mjs`

## Observed behavior after these changes

These changes were sufficient to verify that from Rocket.Chat:
- `--acp spawn codex --bind here` works
- a bound Rocket.Chat conversation can continue into the same ACP session
- existing Rocket.Chat thread context is correctly forwarded into ACP
- Rocket.Chat no longer suffers from the earlier ACP binding availability error

## Known limitations / follow-up

This PR fixes the Rocket.Chat ACP binding gap, but it does not solve every ACP runtime issue we saw during end-to-end testing.

In particular, later testing showed a separate upstream/runtime problem where certain Gitea MCP calls inside ACP/Codex sessions can hang or time out. That appears to be outside this plugin and should be tracked separately in OpenClaw/ACPX.
